### PR TITLE
Fix frontend pagination

### DIFF
--- a/packages/web/src/app/routes/Routes.tsx
+++ b/packages/web/src/app/routes/Routes.tsx
@@ -1,10 +1,10 @@
+import { AuthRequirement, compose } from '@stringsync/common';
 import React from 'react';
-import { compose, AuthRequirement } from '@stringsync/common';
 import { Route, Switch } from 'react-router-dom';
-import { Landing } from './Landing';
-import { Fallback } from './Fallback';
-import { withAuthRequirement } from '../../hocs';
 import { ReturnToRoute } from '../../components/ReturnToRoute';
+import { withAuthRequirement } from '../../hocs';
+import { Fallback } from './Fallback';
+import { Landing } from './Landing';
 import { NotFound } from './NotFound';
 
 const Library = compose(withAuthRequirement(AuthRequirement.NONE))(React.lazy(() => import('./Library')));

--- a/packages/web/src/store/library/librarySlice.ts
+++ b/packages/web/src/store/library/librarySlice.ts
@@ -18,7 +18,7 @@ export const getNotationPage = createAsyncThunk<
   const state = thunk.getState() as RootState;
   const connectionArgs: NotationConnectionArgs = {
     last: args.pageSize,
-    before: state.library.pageInfo.endCursor,
+    before: state.library.pageInfo.startCursor,
   };
   if (state.library.query.length) {
     connectionArgs.query = state.library.query;


### PR DESCRIPTION
The `Library` component was paging backwards and using the `endCursor` to page backwards. However, when paging backwards, the notations are returned in ascending cursor, based on the GraphQL pagination [spec](https://relay.dev/graphql/connections.htm#sec-Edge-order). Therefore, the `endCursor` actually references the cursor we specified in the `before` connection argument.